### PR TITLE
Fixed DevDocs ReadMe Lists Numbering

### DIFF
--- a/doc/devdocs/readme.md
+++ b/doc/devdocs/readme.md
@@ -38,17 +38,17 @@ Once you've discussed your proposed feature/fix/etc. with a team member, and you
 ### Prerequisites for Compiling PowerToys
 
 1. Windows 10 April 2018 Update (version 1803) or newer
-2. Visual Studio Community/Professional/Enterprise 2022 17.4 or newer
-3. Git clone PowerToys repository 
-4. Open started the `PowerToys.sln`
-5, If you see a dialog that says `install extra components` in the solution explorer pane, click `install`
+1. Visual Studio Community/Professional/Enterprise 2022 17.4 or newer
+1. Git clone PowerToys repository 
+1. Open started the `PowerToys.sln`
+1. If you see a dialog that says `install extra components` in the solution explorer pane, click `install`
 
 ### Get Submodules to compile
 We have submodules that need to be initialized before you can compile most parts of PowerToys.  This should be a one time step.
 
 1. Open a terminal
-2. Navigate to the folder you cloned PowerToys to.
-3. Run `git submodule update --init --recursive`
+1. Navigate to the folder you cloned PowerToys to.
+1. Run `git submodule update --init --recursive`
 
 ### Compiling Source Code
 
@@ -65,22 +65,22 @@ Our installer is two parts, an EXE and an MSI.  The EXE (Bootstrapper) contains 
 The installer can only be compiled in `Release` mode, step 1 and 2 must be done before the MSI will be able to be compiled.
 
 1. Compile `PowerToys.sln`. Instructions are listed above.
-2. Compile `BugReportTool.sln` tool. Path from root: `tools\BugReportTool\BugReportTool.sln` (details listed below)
-3. Compile `WebcamReportTool.sln` tool. Path from root: `tools\WebcamReportTool\WebcamReportTool.sln` (details listed below)
-3. Compile `StylesReportTool.sln` tool. Path from root: `tools\StylesReportTool\StylesReportTool.sln` (details listed below)
-4. Compile `PowerToysSetup.sln` Path from root: `installer\PowerToysSetup.sln` (details listed below)
+1. Compile `BugReportTool.sln` tool. Path from root: `tools\BugReportTool\BugReportTool.sln` (details listed below)
+1. Compile `WebcamReportTool.sln` tool. Path from root: `tools\WebcamReportTool\WebcamReportTool.sln` (details listed below)
+1. Compile `StylesReportTool.sln` tool. Path from root: `tools\StylesReportTool\StylesReportTool.sln` (details listed below)
+1. Compile `PowerToysSetup.sln` Path from root: `installer\PowerToysSetup.sln` (details listed below)
 
 ### Prerequisites for building the MSI installer
 
 1. Install the [WiX Toolset Visual Studio 2022 Extension](https://marketplace.visualstudio.com/items?itemName=WixToolset.WixToolsetVisualStudio2022Extension).
-2. Install the [WiX Toolset build tools](https://wixtoolset.org/releases/v3-14-0-6526/).
-3. Download [WiX binaries](https://wixtoolset.org/downloads/v3.14.0.6526/wix314-binaries.zip) and extract `wix.targets` to `C:\Program Files (x86)\WiX Toolset v3.14`.
+1. Install the [WiX Toolset build tools](https://wixtoolset.org/releases/v3-14-0-6526/).
+1. Download [WiX binaries](https://wixtoolset.org/downloads/v3.14.0.6526/wix314-binaries.zip) and extract `wix.targets` to `C:\Program Files (x86)\WiX Toolset v3.14`.
 
 ### Locally building the installer prerequisite projects all at once from the command-line
 
 1. Open a `Developer Command Prompt for VS 2022`
-2. Ensure `nuget.exe` is in your `%path%`
-3. In the repo root, run these commands:
+1. Ensure `nuget.exe` is in your `%path%`
+1. In the repo root, run these commands:
   
 ```
 nuget restore .\tools\BugReportTool\BugReportTool.sln
@@ -96,26 +96,26 @@ msbuild -p:Platform=x64 -p:Configuration=Release .\tools\StylesReportTool\Styles
 ### Locally compiling the Bug reporting tool
 
 1. Open `tools\BugReportTool\BugReportTool.sln`
-2. In Visual Studio, in the `Solutions Configuration` drop-down menu select `Release`
-3. From the `Build` menu, choose `Build Solution`.
+1. In Visual Studio, in the `Solutions Configuration` drop-down menu select `Release`
+1. From the `Build` menu, choose `Build Solution`.
 
 ### Locally compiling the Webcam reporting tool
 
 1. Open `tools\WebcamReportTool\WebcamReportTool.sln`
-2. In Visual Studio, in the `Solutions Configuration` drop-down menu select `Release`
-3. From the `Build` menu, choose `Build Solution`.
+1. In Visual Studio, in the `Solutions Configuration` drop-down menu select `Release`
+1. From the `Build` menu, choose `Build Solution`.
 
 ### Locally compiling the Window styles reporting tool
 
 1. Open `tools\StylesReportTool\StylesReportTool.sln`
-2. In Visual Studio, in the `Solutions Configuration` drop-down menu select `Release`
-3. From the `Build` menu, choose `Build Solution`.
+1. In Visual Studio, in the `Solutions Configuration` drop-down menu select `Release`
+1. From the `Build` menu, choose `Build Solution`.
 
 ### Locally compiling the installer
 
 1. Open `installer\PowerToysSetup.sln`
-2. In Visual Studio, in the `Solutions Configuration` drop-down menu select `Release`
-3. From the `Build` menu choose `Build Solution`.
+1. In Visual Studio, in the `Solutions Configuration` drop-down menu select `Release`
+1. From the `Build` menu choose `Build Solution`.
 
 The resulting `PowerToysSetup.msi` installer will be available in the `installer\PowerToysSetup\x64\Release\` folder.
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- The location of the ReadMe changed is `doc/devdocs/readme.md`
- There were errors in numbering at 2 places in the ReadMe. (Two points displayed in the same line, repeated same number for 2 consecutive points)
- Previously there was a mixture of `1.` `1.` `1.` ... and `1.` `2.` `3.` ... indexing in the readme doc with some errors in the latter which is changed to a uniform use of  `1.` `1.` `1.` ....


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Choose the `1.` `1.` `1.` ... scheme of indexing because it is less error prone (since both the errors were in `1.` `2.` `3.` ... scheme only).

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
--